### PR TITLE
expose a function that sets up a tracer and "runs stuff" within that closure AFTER the tracer is enabled and operational

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
 # DistributedTracer
+
+My "Stupid tricks with Distributed Tracing" - generating traces from XCTest cases.
+
+
+
+## Seeing it
+
+To spin up a Jaeger trace collector:
+
+```
+docker-compose up -d
+```
+
+Run [the tests from this package](https://github.com/heckj/DistributedTracer/blob/main/Tests/DistributedTracerTests/DistributedTracerTests.swift) to generate a few tests:
+
+```
+swift test
+```
+
+Open up a browser to see any traces generated to [http://localhost:16686/](http://localhost:16686/), which accesses the Jaeger running in Docker.
+

--- a/Sources/DistributedTracer/TestTracer.swift
+++ b/Sources/DistributedTracer/TestTracer.swift
@@ -14,43 +14,25 @@ public actor TestTracer {
     // and invoke a flush of the traces before the test execution is summarily
     // terminated.
     public var tracer: (any Tracer)?
-    
 
-    func createTracer(serviceName: String) async -> ServiceGroup {
+    // hanging on to the handle for the detached task that "runs" the tracer, but not
+    // sure if we need to be able to cancel it or not... at least in a test scenario.
+    // Since you can only bootstrap instrumentation once, it seems you can't even manipulate
+    // or replace a tracer once it's set up (at least with how Distributed Tracing is set up
+    // today, so this is private and currently unused.
+    private var tracerRunHandle: Task<Void, any Error>?
+
+    private func createTracer(serviceName: String) -> OTelTracer<OTelRandomIDGenerator<SystemRandomNumberGenerator>, OTelConstantSampler, OTelW3CPropagator, OTelBatchSpanProcessor<OTLPGRPCSpanExporter, ContinuousClock>, ContinuousClock> {
+        let resource = OTelResource(attributes: ["service.name": "\(serviceName)"])
         let environment = OTelEnvironment.detected()
-        let resourceDetection = OTelResourceDetection(detectors: [
-            OTelProcessResourceDetector(),
-            OTelEnvironmentResourceDetector(environment: environment),
-            .manual(OTelResource(attributes: ["service.name": "\(serviceName)"])),
-        ])
-        let resource = await resourceDetection.resource(environment: environment, logLevel: .trace)
-
-        /*
-         Bootstrap the logging system to use the OTel metadata provider.
-         This will automatically include trace and span IDs in log statements
-         from your app and its dependencies.
-         */
-        LoggingSystem.bootstrap({ label, _ in
-            var handler = StreamLogHandler.standardOutput(label: label)
-            // We set the lowest possible minimum log level to see all log statements.
-            handler.logLevel = .trace
-            return handler
-        }, metadataProvider: .otel)
-        let logger = Logger(label: "example")
-
-        /*
-         Here we create an OTel span exporter that sends spans via gRPC to an OTel collector.
-         */
+        // Here we create an OTel span exporter that sends spans via gRPC to an OTel collector.
         let exporter = try! OTLPGRPCSpanExporter(configuration: .init(environment: environment))
-        /*
-         This exporter is passed to a batch span processor.
-         The processor receives ended spans from the tracer, batches them up, and finally forwards them to the exporter.
-         */
+        // This exporter is passed to a batch span processor.
+
+        // The processor receives ended spans from the tracer, batches them up, and finally
+        // forwards them to the exporter.
         let processor = OTelBatchSpanProcessor(exporter: exporter, configuration: .init(environment: environment))
-        /*
-         We need to await tracer initialization since the tracer needs
-         some time to detect attributes about the resource being traced.
-         */
+
         let myTracer = OTelTracer(
             idGenerator: OTelRandomIDGenerator(),
             sampler: OTelConstantSampler(isOn: true),
@@ -59,75 +41,44 @@ public actor TestTracer {
             environment: environment,
             resource: resource
         )
-        /*
-         Once we have a tracer, we bootstrap the instrumentation system to use it.
-         This configures your application code and any of your dependencies to use the OTel tracer.
-         */
-        InstrumentationSystem.bootstrap(myTracer)
-        
-        let serviceGroup = ServiceGroup(
-            services: [myTracer],
-            gracefulShutdownSignals: [.sigint],
-            logger: logger
-        )
 
-        return serviceGroup
+        // Once we have a tracer, we bootstrap the instrumentation system to use it.
+        // You can only bootstrap an instrument ONCE per process (ref:
+        // https://github.com/apple/swift-distributed-tracing/blob/main/Sources/Instrumentation/InstrumentationSystem.swift#L38-L39
+        // So this has to hold for all bits using the tracer.
+        InstrumentationSystem.bootstrap(myTracer)
+
+        return myTracer
     }
-    
+
     // original, hack it into place mechanism - just run something in a detached task in the background.
     // yeah, kind of ugly
     public func bootstrap(serviceName: String) async {
         if !bootstrapped {
-            let serviceGroup = await self.createTracer(serviceName: serviceName)
+            let tracer = createTracer(serviceName: serviceName)
 
             // Set up a detached task to run this in the background indefinitely.
             // - no cancellation, just GO
-            Task {
-                try await serviceGroup.run()
+            tracerRunHandle = Task {
+                try await tracer.run()
             }
 
+            self.tracer = tracer
             bootstrapped = true
         }
     }
 
-    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) // for TaskLocal ServiceContext
-    public static func withTracer(
-        _ serviceName: String,
-        _ operation: () async throws -> ()
-    ) async rethrows -> () {
-        let serviceGroup = await shared.createTracer(serviceName: serviceName)
-        
-        return try await withThrowingTaskGroup(of: Void.self) { taskGroup in
-            taskGroup.addTask {
-                try await serviceGroup.run() // !important
-            }
-
-            // So it turns out this idea is illegal, because we're running the operation (our test code)
-            // where it's trying to set a TaskLocal variable, which apparently isn't kosher.
-            // Per the error when I run a test using this:
-            //
-            //Thread 2: error: task-local: detected illegal task-local value binding at Tracing/TracerProtocol+Legacy.swift:330.
-            //Task-local values must only be set in a structured-context, such as: around any (synchronous or asynchronous function invocation), around an 'async let' declaration, or around a 'with(Throwing)TaskGroup(...){ ... }' invocation. Notably, binding a task-local value is illegal *within the body* of a withTaskGroup invocation.
-            //
-            //The following example is illegal:
-            //
-            //    await withTaskGroup(...) { group in
-            
-            try await operation()
-            
-            // IDEA: we don't have direct access to tracer here, or it's components, but it
-            // could be an interesting idea to capture the spans in this area, not externally
-            // publishing them, and then making them available to a test to inspect, assert
-            // against, etc.
-            //
-            // In that case, the wrapping method would return some data structure with spans
-            // embedded within it...
-
-            // To shutdown the tracer, cancel its run method by cancelling the taskGroup.
-            taskGroup.cancelAll()
-        }
+    private init() {
+        // Akin to the Instrumentation system, the Logging
+        // system can only be bootstrapped once per process. Since it's orthogonal
+        // setup, but used by Tracing, we set it up here in the default initializer.
+        LoggingSystem.bootstrap({ label, _ in
+            var handler = StreamLogHandler.standardOutput(label: label)
+            // We set the lowest possible minimum log level to see all log statements.
+            handler.logLevel = .trace
+            return handler
+        }, metadataProvider: .otel)
+        let logger = Logger(label: "TestTracer Setup")
+        logger.debug("Logging system initialized")
     }
-    
-
-    private init() {}
 }

--- a/Sources/DistributedTracer/TestTracer.swift
+++ b/Sources/DistributedTracer/TestTracer.swift
@@ -10,65 +10,75 @@ public actor TestTracer {
     private var bootstrapped = false
     public static let shared = TestTracer()
 
-    public var tracer:
-        // (any Tracer)?
-        OTelTracer<OTelRandomIDGenerator<SystemRandomNumberGenerator>, OTelConstantSampler, OTelW3CPropagator, OTelBatchSpanProcessor<OTLPGRPCSpanExporter, ContinuousClock>, ContinuousClock>?
+    // exposing the tracer so that test shutdown methods can get ahold of it
+    // and invoke a flush of the traces before the test execution is summarily
+    // terminated.
+    public var tracer: (any Tracer)?
+    
 
+    func createTracer(serviceName: String) async -> ServiceGroup {
+        let environment = OTelEnvironment.detected()
+        let resourceDetection = OTelResourceDetection(detectors: [
+            OTelProcessResourceDetector(),
+            OTelEnvironmentResourceDetector(environment: environment),
+            .manual(OTelResource(attributes: ["service.name": "\(serviceName)"])),
+        ])
+        let resource = await resourceDetection.resource(environment: environment, logLevel: .trace)
+
+        /*
+         Bootstrap the logging system to use the OTel metadata provider.
+         This will automatically include trace and span IDs in log statements
+         from your app and its dependencies.
+         */
+        LoggingSystem.bootstrap({ label, _ in
+            var handler = StreamLogHandler.standardOutput(label: label)
+            // We set the lowest possible minimum log level to see all log statements.
+            handler.logLevel = .trace
+            return handler
+        }, metadataProvider: .otel)
+        let logger = Logger(label: "example")
+
+        /*
+         Here we create an OTel span exporter that sends spans via gRPC to an OTel collector.
+         */
+        let exporter = try! OTLPGRPCSpanExporter(configuration: .init(environment: environment))
+        /*
+         This exporter is passed to a batch span processor.
+         The processor receives ended spans from the tracer, batches them up, and finally forwards them to the exporter.
+         */
+        let processor = OTelBatchSpanProcessor(exporter: exporter, configuration: .init(environment: environment))
+        /*
+         We need to await tracer initialization since the tracer needs
+         some time to detect attributes about the resource being traced.
+         */
+        let myTracer = OTelTracer(
+            idGenerator: OTelRandomIDGenerator(),
+            sampler: OTelConstantSampler(isOn: true),
+            propagator: OTelW3CPropagator(),
+            processor: processor,
+            environment: environment,
+            resource: resource
+        )
+        /*
+         Once we have a tracer, we bootstrap the instrumentation system to use it.
+         This configures your application code and any of your dependencies to use the OTel tracer.
+         */
+        InstrumentationSystem.bootstrap(myTracer)
+        
+        let serviceGroup = ServiceGroup(
+            services: [myTracer],
+            gracefulShutdownSignals: [.sigint],
+            logger: logger
+        )
+
+        return serviceGroup
+    }
+    
+    // original, hack it into place mechanism - just run something in a detached task in the background.
+    // yeah, kind of ugly
     public func bootstrap(serviceName: String) async {
         if !bootstrapped {
-            let environment = OTelEnvironment.detected()
-            let resourceDetection = OTelResourceDetection(detectors: [
-                OTelProcessResourceDetector(),
-                OTelEnvironmentResourceDetector(environment: environment),
-                .manual(OTelResource(attributes: ["service.name": "\(serviceName)"])),
-            ])
-            let resource = await resourceDetection.resource(environment: environment, logLevel: .trace)
-
-            /*
-             Bootstrap the logging system to use the OTel metadata provider.
-             This will automatically include trace and span IDs in log statements
-             from your app and its dependencies.
-             */
-            LoggingSystem.bootstrap({ label, _ in
-                var handler = StreamLogHandler.standardOutput(label: label)
-                // We set the lowest possible minimum log level to see all log statements.
-                handler.logLevel = .trace
-                return handler
-            }, metadataProvider: .otel)
-            let logger = Logger(label: "example")
-
-            /*
-             Here we create an OTel span exporter that sends spans via gRPC to an OTel collector.
-             */
-            let exporter = try! OTLPGRPCSpanExporter(configuration: .init(environment: environment))
-            /*
-             This exporter is passed to a batch span processor.
-             The processor receives ended spans from the tracer, batches them up, and finally forwards them to the exporter.
-             */
-            let processor = OTelBatchSpanProcessor(exporter: exporter, configuration: .init(environment: environment))
-            /*
-             We need to await tracer initialization since the tracer needs
-             some time to detect attributes about the resource being traced.
-             */
-            let myTracer = OTelTracer(
-                idGenerator: OTelRandomIDGenerator(),
-                sampler: OTelConstantSampler(isOn: true),
-                propagator: OTelW3CPropagator(),
-                processor: processor,
-                environment: environment,
-                resource: resource
-            )
-            /*
-             Once we have a tracer, we bootstrap the instrumentation system to use it.
-             This configures your application code and any of your dependencies to use the OTel tracer.
-             */
-            InstrumentationSystem.bootstrap(myTracer)
-
-            let serviceGroup = ServiceGroup(
-                services: [myTracer],
-                gracefulShutdownSignals: [.sigint],
-                logger: logger
-            )
+            let serviceGroup = await self.createTracer(serviceName: serviceName)
 
             // Set up a detached task to run this in the background indefinitely.
             // - no cancellation, just GO
@@ -77,9 +87,47 @@ public actor TestTracer {
             }
 
             bootstrapped = true
-            tracer = myTracer
         }
     }
+
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) // for TaskLocal ServiceContext
+    public static func withTracer(
+        _ serviceName: String,
+        _ operation: () async throws -> ()
+    ) async rethrows -> () {
+        let serviceGroup = await shared.createTracer(serviceName: serviceName)
+        
+        return try await withThrowingTaskGroup(of: Void.self) { taskGroup in
+            taskGroup.addTask {
+                try await serviceGroup.run() // !important
+            }
+
+            // So it turns out this idea is illegal, because we're running the operation (our test code)
+            // where it's trying to set a TaskLocal variable, which apparently isn't kosher.
+            // Per the error when I run a test using this:
+            //
+            //Thread 2: error: task-local: detected illegal task-local value binding at Tracing/TracerProtocol+Legacy.swift:330.
+            //Task-local values must only be set in a structured-context, such as: around any (synchronous or asynchronous function invocation), around an 'async let' declaration, or around a 'with(Throwing)TaskGroup(...){ ... }' invocation. Notably, binding a task-local value is illegal *within the body* of a withTaskGroup invocation.
+            //
+            //The following example is illegal:
+            //
+            //    await withTaskGroup(...) { group in
+            
+            try await operation()
+            
+            // IDEA: we don't have direct access to tracer here, or it's components, but it
+            // could be an interesting idea to capture the spans in this area, not externally
+            // publishing them, and then making them available to a test to inspect, assert
+            // against, etc.
+            //
+            // In that case, the wrapping method would return some data structure with spans
+            // embedded within it...
+
+            // To shutdown the tracer, cancel its run method by cancelling the taskGroup.
+            taskGroup.cancelAll()
+        }
+    }
+    
 
     private init() {}
 }

--- a/Tests/DistributedTracerTests/DistributedTracerTests.swift
+++ b/Tests/DistributedTracerTests/DistributedTracerTests.swift
@@ -1,12 +1,18 @@
-@testable import DistributedTracer
+import DistributedTracer
+import Tracing
 import XCTest
 
 final class DistributedTracerTests: XCTestCase {
-    func testExample() throws {
-        // XCTest Documentation
-        // https://developer.apple.com/documentation/xctest
-
-        // Defining Test Cases and Test Methods
-        // https://developer.apple.com/documentation/xctest/defining_test_cases_and_test_methods
+    
+    func testClosureInvokerTest() async throws {
+        try await TestTracer.withTracer("testClosureInvokerTest") {
+            try await withSpan("example span") { span in
+                
+                try await Task.sleep(for: .milliseconds(50))
+                span.addEvent(SpanEvent("EVENT!"))
+                try await Task.sleep(for: .milliseconds(50))
+                span.addEvent(SpanEvent("SECOND EVENT!"))
+            }
+        }
     }
 }

--- a/Tests/DistributedTracerTests/DistributedTracerTests.swift
+++ b/Tests/DistributedTracerTests/DistributedTracerTests.swift
@@ -3,16 +3,41 @@ import Tracing
 import XCTest
 
 final class DistributedTracerTests: XCTestCase {
-    
+    override func setUp() async throws {
+        await TestTracer.shared.bootstrap(serviceName: "TracerTests")
+    }
+
+    override func tearDown() async throws {
+        if let tracer = await TestTracer.shared.tracer {
+            tracer.forceFlush()
+            // Testing does NOT have a polite shutdown waiting for a flush to complete, so
+            // we explicitly give it some extra time here to flush out any spans remaining.
+            try await Task.sleep(for: .milliseconds(100))
+
+            // This would be a whole lot better at the tail end of the entire suite, or at least
+            // at the class tearDown, but `override class func tearDown` doesn't appear to have
+            // an async callback where we can do cleanup/flush work like this, so it's in
+            // each test execution. Sorry about that.
+        }
+    }
+
     func testClosureInvokerTest() async throws {
-        try await TestTracer.withTracer("testClosureInvokerTest") {
-            try await withSpan("example span") { span in
-                
-                try await Task.sleep(for: .milliseconds(50))
-                span.addEvent(SpanEvent("EVENT!"))
-                try await Task.sleep(for: .milliseconds(50))
-                span.addEvent(SpanEvent("SECOND EVENT!"))
-            }
+        try await withSpan("example span") { span in
+
+            try await Task.sleep(for: .milliseconds(50))
+            span.addEvent(SpanEvent("EVENT!"))
+            try await Task.sleep(for: .milliseconds(50))
+            span.addEvent(SpanEvent("SECOND EVENT!"))
+        }
+    }
+
+    func testClosureInvokerTestAgain() async throws {
+        try await withSpan("example span") { span in
+
+            try await Task.sleep(for: .milliseconds(50))
+            span.addEvent(SpanEvent("EVENT!"))
+            try await Task.sleep(for: .milliseconds(50))
+            span.addEvent(SpanEvent("SECOND EVENT!"))
         }
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+services:
+  jaeger:
+    # Jaeger is one of many options we can choose from as our distributed tracing backend.
+    # It supports OTLP out of the box so it's very easy to get started.
+    # https://www.jaegertracing.io
+    image: jaegertracing/all-in-one
+    ports:
+      - "4317:4317" # This is where the OTLPGRPCSpanExporter sends its spans
+      - "16686:16686" # This is Jaeger's Web UI, visualizing recorded traces


### PR DESCRIPTION
test fails, need to investigate (and learn) more to see if I can make something like this work